### PR TITLE
Fix LEDs in firmware

### DIFF
--- a/servo_funhouse/servo_funhouse.ino
+++ b/servo_funhouse/servo_funhouse.ino
@@ -18,7 +18,7 @@ void setup() {
         servo[i].write(180);
 
     for ( int i = 0; i < 6; i++ )
-        pinMode(i, OUTPUT);
+        pinMode(pin_map[i], OUTPUT);
 }
 
 #define PACKET_START 1337


### PR DESCRIPTION
Fixes LEDs in firmware - output pins were not being set correctly. The array index was being set to output, rather than the actual pin :(

